### PR TITLE
Fix: Correct $response['nbcb'] variable handling in WooCommerce 3.2.7

### DIFF
--- a/WooCommerce/woocommerce_rms_normal/class-gateway.php
+++ b/WooCommerce/woocommerce_rms_normal/class-gateway.php
@@ -861,7 +861,7 @@ class WC_Molpay_Gateway extends WC_Payment_Gateway
      */
     public function acknowledgeResponse($response)
     {
-        if ($isset($response['nbcb']) && response['nbcb'] == '1') {
+        if (isset($response['nbcb']) && $response['nbcb'] == '1') {
             echo "CBTOKEN:MPSTATOK";
             exit;
         } else {


### PR DESCRIPTION
## Description
Fixed the `$response['nbcb']` variable.